### PR TITLE
Updating the README to include instruction on missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Add the following lines to your apache2 configuration under the Intranet section
 
 The plugin will construct this stanza for you. If Plugins are already enabled just install the plugin and it will construct the stanza for you to copy paste into your apache2 configuration file.
 
+Ensure Carp::Always is installed
+	
+    sudo apt-get install libcarp-always-perl
+
 With these changes complete Restart or Reload Apache:
 
     sudo service apache2 reload


### PR DESCRIPTION
When trying to install this on a Koha DevBox, I ran into some errors to do with compilation. Digging a bit deeper, these errors turned out to be due to missing the Carp::Always module. This patch adds an instruction to the README.md to help others avoid this issue.